### PR TITLE
Set vnc as display for rosfsw, same way as it is for rosgsw

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -32,6 +32,8 @@ services:
     command: "./run_rosfsw.sh"
     env_file:
       - env.sh
+    environment:
+      - DISPLAY=novnc:0.0
     networks:
       spaceip:
         ipv4_address: 10.5.0.4


### PR DESCRIPTION
I noticed that **rosfsw** is not set to use vnc as display, this PR adds that setting.