### PR TITLE
Feature/generate images action

### DIFF
--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -62,15 +62,17 @@ jobs:
           vcs import src < https.repos
 
       # Source setup_dev and call docker-compose build
-      - name: Source setup_dev
+      - name: Source setup_dev and call docker-compose build
         run: |
           cd brash_docker
           source setup_dev.sh
           docker-compose build
           
-      # Build cfs_base
+      # Build cfs_base (call build_cfe)
       - name: Build
         run: |
+          cd brash_docker
+          source setup_dev.sh
           build_cfe prep SIMULATION=native
           build_cfe install          
           

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -48,24 +48,31 @@ jobs:
         with:
           images: ${{env.REGISTRY}}/${{env.IMAGE_NAME}}   
       
-      # Clone this repository
+      # This repository is checked out! It needs to pull recursively
       - name: Clone brash_docker and submodules (cFS, brash and juicer)
         run: |
-          git clone --recursive http://github.com/traclabs/brash_docker.git brash_docker                    
+          echo "Print current location 1"
+          pwd
+          git submodule update --init --recursive                    
           
       # Clone brash workspace repositories
       - name: Clone brash workspace repositories
         run: |
-          cd brash_docker/brash
+          echo "Print current location 2"
+          pwd
+          echo "Print ls"
+          ls
+          cd brash
           pip3 install vcstool
           mkdir src
           vcs import src < https.repos
-
+          
       # Source setup_dev and call docker-compose build
       - name: Source setup_dev and call docker-compose build
         run: |
-          cd brash_docker
-          
+          echo "Print current location 3 = is it in brash?"
+          pwd
+          cd ..          
           shopt -s expand_aliases        
           source setup_dev.sh
           
@@ -74,8 +81,6 @@ jobs:
       # Build cfs_base (call build_cfe)
       - name: Build cfs_base
         run: |
-          cd brash_docker
-          
           shopt -s expand_aliases
           source setup_dev.sh
           
@@ -86,7 +91,6 @@ jobs:
       # this dummy will use as base cfs-base / brash-ros-base
       - name: Create temp cfs-base dockerfile
         run: |
-          cd brash_docker
           touch cfs_base_temp.Dockerfile
           echo "FROM cfs-base" > cfs_base_temp.Dockerfile
           echo "running ls"
@@ -103,7 +107,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           #build-args: SRC_DIR=src
-          context: brash_docker
+          context: .
           file: ./cfs_base_temp.Dockerfile
           push: ${{github.event_name != 'pull_request' }}
           tags: cfs-base #${{steps.meta.outputs.tags}}

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -91,7 +91,7 @@ jobs:
       # (not using build-and-push action as passing images is giving me trouble)
       - name: Push cfs-base
         run: |
-          local_tag="cfe-base"
+          local_tag="cfs-base"
           remote_tag="${{env.REGISTRY}}/${{env.IMAGE_NAME}}:${local_tag}"
           docker tag $local_tag $remote_tag
           docker push $remote_tag

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -89,6 +89,11 @@ jobs:
           cd brash_docker
           touch cfs_base_temp.Dockerfile
           echo "FROM cfs-base" > cfs_base_temp.Dockerfile
+          echo "running ls"
+          ls
+          echo "Checking images"
+          docker image ls
+          
           
       # Build the cfs-base docker image  and push it with buildx
       - name: Build and push Docker image

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -65,19 +65,20 @@ jobs:
       - name: Source setup_dev and call docker-compose build
         run: |
           cd brash_docker
-          shopt -s expand_aliases
+          
+          shopt -s expand_aliases        
           source setup_dev.sh
-          echo "Listing aliases"
-          alias
+          
           docker-compose build
           
       # Build cfs_base (call build_cfe)
       - name: Build cfs_base
         run: |
           cd brash_docker
-          echo "Listing aliases 2"
-          alias
-
+          
+          shopt -s expand_aliases
+          source setup_dev.sh
+          
           build_cfe prep SIMULATION=native
           build_cfe install          
           

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -93,6 +93,8 @@ jobs:
           ls
           echo "Checking images"
           docker image ls
+          echo "Location"
+          pwd
           
           
       # Build the cfs-base docker image  and push it with buildx

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -2,7 +2,7 @@ name: Create cfs_base_docker image
 
 on:
   workflow_dispatch:
-  
+   # Push
   pull_request:
     branches:
       - devel

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -100,7 +100,7 @@ jobs:
       # (not using build-and-push action as passing images is giving me trouble)
       - name: Push brash-ros-base
         run: |
-          local_tag = "brash-ros-base"
+          local_tag="brash-ros-base"
           remote_tag="${{env.REGISTRY}}/${{env.IMAGE_NAME}}:${local_tag}"
           docker tag $local_tag $remote_tag
           docker push $remote_tag

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -65,14 +65,19 @@ jobs:
       - name: Source setup_dev and call docker-compose build
         run: |
           cd brash_docker
+          shopt -s expand_aliases
           source setup_dev.sh
+          echo "Listing aliases"
+          alias
           docker-compose build
           
       # Build cfs_base (call build_cfe)
-      - name: Build
+      - name: Build cfs_base
         run: |
           cd brash_docker
-          source setup_dev.sh
+          echo "Listing aliases 2"
+          alias
+
           build_cfe prep SIMULATION=native
           build_cfe install          
           

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -51,17 +51,11 @@ jobs:
       # This repository is checked out! It needs to pull recursively
       - name: Clone brash_docker and submodules (cFS, brash and juicer)
         run: |
-          echo "Print current location 1"
-          pwd
           git submodule update --init --recursive                    
           
       # Clone brash workspace repositories
       - name: Clone brash workspace repositories
         run: |
-          echo "Print current location 2"
-          pwd
-          echo "Print ls"
-          ls
           cd brash
           pip3 install vcstool
           mkdir src
@@ -70,34 +64,44 @@ jobs:
       # Source setup_dev and call docker-compose build
       - name: Source setup_dev and call docker-compose build
         run: |
-          echo "Print current location 3 = is it in brash?"
-          pwd
           shopt -s expand_aliases        
           source setup_dev.sh
           
           docker-compose build
           
-      # Build cfs_base (call build_cfe)
-      - name: Build cfs_base
+      # Build cfs_base
+      - name: Build cfs-base
         run: |
           shopt -s expand_aliases
           source setup_dev.sh
           
           build_cfe prep SIMULATION=native
           build_cfe install          
-      
-      # Push cfs_base image, after tagging it correctly
-      # (not using build-and-push action as passing images is giving me trouble)
-      - name: Push cfs_base
+
+      # Build brash-ros-base
+      - name: Build brash-ros-base
         run: |
-          echo "testing: "
-          echo "${{env.REGISTRY}}"
-          echo "testing 2"
-          echo "${{env.IMAGE_NAME}}"
-          echo "Setting remote tag"
-          remote_tag="ghcr.io/traclabs/brash_docker:cfe-base"
-          echo "Docker tag"
-          docker tag cfs-base $remote_tag
-          echo "Docker push"
+          shopt -s expand_aliases
+          source setup_dev.sh
+          
+          build_ros          
+
+      
+      # Push cfs-base image
+      # (not using build-and-push action as passing images is giving me trouble)
+      - name: Push cfs-base
+        run: |
+          local_tag="cfe-base"
+          remote_tag="${{env.REGISTRY}}/${{env.IMAGE_NAME}}:${local_tag}"
+          docker tag $local_tag $remote_tag
+          docker push $remote_tag
+      
+      # Push brash-ros-base image
+      # (not using build-and-push action as passing images is giving me trouble)
+      - name: Push brash-ros-base
+        run: |
+          local_tag = "brash-ros-base"
+          remote_tag="${{env.REGISTRY}}/${{env.IMAGE_NAME}}:${local_tag}"
+          docker tag $local_tag $remote_tag
           docker push $remote_tag
       

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -86,30 +86,18 @@ jobs:
           build_cfe prep SIMULATION=native
           build_cfe install          
       
-      # Create a dummy dockerfile for build-and-push
-      # this dummy will use as base cfs-base / brash-ros-base
-      - name: Create temp cfs-base dockerfile
+      # Push cfs_base image, after tagging it correctly
+      # (not using build-and-push action as passing images is giving me trouble)
+      - name: Push cfs_base
         run: |
-          touch cfs_base_temp.Dockerfile
-          echo "FROM cfs-base" > cfs_base_temp.Dockerfile
-          echo "running ls"
-          ls
-          echo "Checking images"
-          docker image ls
-          echo "Location"
-          pwd
-          
-          
-      # Build the cfs-base docker image  and push it with buildx
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v5
-        with:
-          #build-args: SRC_DIR=src
-          context: .
-          file: ./cfs_base_temp.Dockerfile
-          push: ${{github.event_name != 'pull_request' }}
-          tags: cfs-base #${{steps.meta.outputs.tags}}
-          labels: ${{steps.meta.outputs.labels}}
-          no-cache: true
-  
+          echo "testing: "
+          echo "${{env.REGISTRY}}"
+          echo "testing 2"
+          echo "${{env.IMAGE_NAME}}"
+          echo "Setting remote tag"
+          remote_tag="ghcr.io/traclabs/brash_docker:cfe-base"
+          echo "Docker tag"
+          docker tag cfs-base $remote_tag
+          echo "Docker push"
+          docker push $remote_tag
+      

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -72,7 +72,6 @@ jobs:
         run: |
           echo "Print current location 3 = is it in brash?"
           pwd
-          cd ..          
           shopt -s expand_aliases        
           source setup_dev.sh
           

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -1,4 +1,4 @@
-name: Create cfs_base_docker image
+name: Create cfs-base and brash-ros-base docker images
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -81,17 +81,25 @@ jobs:
           
           build_cfe prep SIMULATION=native
           build_cfe install          
+      
+      # Create a dummy dockerfile for build-and-push
+      # this dummy will use as base cfs-base / brash-ros-base
+      - name: Create temp cfs-base dockerfile
+        run: |
+          cd brash_docker
+          touch cfs_base_temp.Dockerfile
+          echo "FROM cfs-base" > cfs_base_temp.Dockerfile
           
       # Build the cfs-base docker image  and push it with buildx
-      #- name: Build and push Docker image
-      #  id: build-and-push
-      #  uses: docker/build-push-action@v5
-      #  with:
-      #    #build-args: SRC_DIR=src
-      #    context: brash_docker
-      #    file: ./cfs-Dockerfile
-      #    push: ${{github.event_name != 'pull_request' }}
-      #    tags: ${{steps.meta.outputs.tags}}
-      #    labels: ${{steps.meta.outputs.labels}}
-      #    no-cache: true
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          #build-args: SRC_DIR=src
+          context: brash_docker
+          file: ./cfs_base_temp.Dockerfile
+          push: ${{github.event_name != 'pull_request' }}
+          tags: cfs-base #${{steps.meta.outputs.tags}}
+          labels: ${{steps.meta.outputs.labels}}
+          no-cache: true
   

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -51,7 +51,7 @@ jobs:
       # Clone this repository
       - name: Clone brash_docker and submodules (cFS, brash and juicer)
         run: |
-          git clone --recursive git@github.com:traclabs/brash_docker.git brash_docker                    
+          git clone --recursive http://github.com/traclabs/brash_docker.git brash_docker                    
           
       # Clone brash workspace repositories
       - name: Clone brash workspace repositories

--- a/.github/workflows/build_cfs_base_docker.yaml
+++ b/.github/workflows/build_cfs_base_docker.yaml
@@ -47,24 +47,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{env.REGISTRY}}/${{env.IMAGE_NAME}}   
-         
-      # Set up SSH key clone private repositories
-      - name: Configure SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan bitbucket.org >> ~/.ssh/known_hosts
       
       # Clone this repository
       - name: Clone brash_docker and submodules (cFS, brash and juicer)
         run: |
-          export GIT_SSH_COMMAND="ssh -o StrictHostKeyChecking=no"
-          git clone git@github.com:traclabs/brash_docker.git brash_docker
-          cd brash_docker
-          perl -i -p -e 's|https://(.*?)/|git@\1:|g' .gitmodules
-          git submodule init
-          git submodule update            
+          git clone --recursive git@github.com:traclabs/brash_docker.git brash_docker                    
           
       # Clone brash workspace repositories
       - name: Clone brash workspace repositories
@@ -72,27 +59,31 @@ jobs:
           cd brash_docker/brash
           pip3 install vcstool
           mkdir src
-          vcs import src < ssh.repos
+          vcs import src < https.repos
 
-      # Clone cFS and submodules
-      - name: Clone cFS submodules
+      # Source setup_dev and call docker-compose build
+      - name: Source setup_dev
         run: |
-          cd brash_docker/cFS
-          git submodule init
-          git submodule update
-          cp cfe/cmake/Makefile.sample Makefile
-          cp -r cfe/cmake/sample_defs sample_defs
+          cd brash_docker
+          source setup_dev.sh
+          docker-compose build
           
-      # Build and push docker imag with buildx
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v5
-        with:
-          #build-args: SRC_DIR=src
-          context: brash_docker
-          file: ./cfs-Dockerfile
-          push: ${{github.event_name != 'pull_request' }}
-          tags: ${{steps.meta.outputs.tags}}
-          labels: ${{steps.meta.outputs.labels}}
-          no-cache: true
+      # Build cfs_base
+      - name: Build
+        run: |
+          build_cfe prep SIMULATION=native
+          build_cfe install          
+          
+      # Build the cfs-base docker image  and push it with buildx
+      #- name: Build and push Docker image
+      #  id: build-and-push
+      #  uses: docker/build-push-action@v5
+      #  with:
+      #    #build-args: SRC_DIR=src
+      #    context: brash_docker
+      #    file: ./cfs-Dockerfile
+      #    push: ${{github.event_name != 'pull_request' }}
+      #    tags: ${{steps.meta.outputs.tags}}
+      #    labels: ${{steps.meta.outputs.labels}}
+      #    no-cache: true
   


### PR DESCRIPTION
This PR adds a github action to generate the Docker images using a github action. As you can see in the .yaml file, the action follows the steps delineated in the README file (for the dev mode) to build 2 images:

- cfs-base
- brash-ros-base

And then pushes these images to the Packages section of this repo (https://github.com/traclabs/brash_docker/pkgs/container/brash_docker).  This action can be triggered manually, so it will not generate images periodically for now.