### PR TITLE
Added juicer build step

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -22,7 +22,9 @@ services:
       dockerfile: brash.Dockerfile
       target: rosgsw-dev
     volumes:
+      - "./cFS:/code/cFS"
       - "./brash:/code/brash"
+      - "./juicer:/code/juicer"
     working_dir: /code/brash
   rosfsw:
     extends:

--- a/scripts/build_brash.sh
+++ b/scripts/build_brash.sh
@@ -7,12 +7,22 @@ echo ""
 COMPOSE_FILE="docker-compose-dev.yml"
 CODE_DIR="/code"
 
+# Build BRASH workspace
 docker compose -f ${COMPOSE_FILE} run -w ${CODE_DIR}/brash rosgsw colcon build --symlink-install
 ret=$?
 if [ $ret -ne 0 ]; then
-  echo "!! Failed in colcon build step !!"
+  echo "!! Failed in colcon build step that builds brash workspace !!"
   return 1  
 fi
+
+# Build juicer
+docker compose -f ${COMPOSE_FILE} run -w ${CODE_DIR}/juicer rosgsw make
+ret=$?
+if [ $ret -ne 0 ]; then
+  echo "!! Failed in colcon build step that builds juicer !!"
+  return 1
+fi
+
   
 echo ""
 echo "##### Done! #####"


### PR DESCRIPTION
Our docker setup was only building cFS and brash. It was downloading juicer but not building it. This PR does:

1. Add a step in the scripts to build juicer
2.  Add a mounting point so we mount cFS and juicer (in addition to brash) for the rosgsw service. This is only needed if we  do things like generating messages.