### PR TITLE
Increased mqueue limit for optimum cFE behavior.

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -6,6 +6,11 @@ services:
     command: "./core-cpu2"
     environment:
       - DISPLAY=novnc:0.0
+    # Enable 123 forwarding to access/test the cFE NTP server from outside docker
+#    ports:
+#      - "123:123/udp"
+    sysctls:
+      - fs.mqueue.msg_max=64
     networks:
       spaceip:
         ipv4_address: 10.5.0.3


### PR DESCRIPTION
Note: Untested if this additional flag is valid for podman + github actions.  This docker-compose flag is one of 3 changes (including those in cfe_cfdp and cfs repos) to reduce or eliminate dropped packets during large CFDP transfers.  

Increasing the queue size is strongly recommended, but may not be required for functionality in all cases.